### PR TITLE
Add storageAccountName parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,20 +71,20 @@ const configuration: RocketFilesUserConfiguration = {
 Booster.configure('production', (config: BoosterConfig): void => {
   config.appName = 'test-rockets-files'
   config.providerPackage = '@boostercloud/framework-provider-azure'
-  config.rockets = [new BoosterRocketFiles().rocketForAzure(config, configuration)]
+  config.rockets = [new BoosterRocketFiles(config, configuration).rocketForAzure()]
 })
 
 Booster.configure('local', (config: BoosterConfig): void => {
   config.appName = 'test-rockets-files'
   config.providerPackage = '@boostercloud/framework-provider-local'
-  config.rockets = [new BoosterRocketFiles().rocketForLocal(config, configuration)]
+  config.rockets = [new BoosterRocketFiles(config, configuration).rocketForLocal()]
 })
 ```
 
 Available parameters are:
 
-- `rocketProviderPackage` Rocket package that handle your infrastructure.
-- `params[directory]` A list of folders
+- `directories` A list of folders where the files will be stored
+- `containerName`: Directories container
 
 ### PresignedPut Usage
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ Available parameters are:
 - `directories` A list of folders where the files will be stored
 - `containerName`: Directories container
 
+For Azure provider you can configure the storage account name. You need to set the `storageAccountName` in the `rocketForAzure` method.
+
+```typescript
+  config.rockets = [
+    new BoosterRocketFiles(config, rocketFilesConfiguration).rocketForAzure({
+      storageAccountName: 'myproject123456',
+    }),
+  ]
+```
+
 ### PresignedPut Usage
 
 Create a command in your application and call the `presignedPut` method on the FileHandler class with the `directory` and `filename` you want to upload.

--- a/packages/rocket-file-uploads-azure-infrastructure/src/functions/functions.ts
+++ b/packages/rocket-file-uploads-azure-infrastructure/src/functions/functions.ts
@@ -1,15 +1,18 @@
 import { ApplicationSynthStack, FunctionDefinition } from '@boostercloud/framework-provider-azure-infrastructure'
 import { BoosterConfig } from '@boostercloud/framework-types'
-import { RocketFilesParams } from '@boostercloud/rocket-file-uploads-types'
+import { RocketFilesConfiguration } from '@boostercloud/rocket-file-uploads-types'
 import { getFunctionAppName } from '../helper'
 import { RocketFilesFileUploadedFunction } from './rocket-files-file-uploaded-function'
 
 export class Functions {
-  static mountFunctions(params: RocketFilesParams, config: BoosterConfig): Array<FunctionDefinition> {
-    return [RocketFilesFileUploadedFunction.getFunctionDefinition(config, params.containerName)]
+  static mountFunctions(configuration: RocketFilesConfiguration, config: BoosterConfig): Array<FunctionDefinition> {
+    return [RocketFilesFileUploadedFunction.getFunctionDefinition(config, configuration.containerName)]
   }
 
-  static getFunctionAppName(params: RocketFilesParams, applicationSynthStack: ApplicationSynthStack): string {
+  static getFunctionAppName(
+    configuration: RocketFilesConfiguration,
+    applicationSynthStack: ApplicationSynthStack
+  ): string {
     return getFunctionAppName(applicationSynthStack)
   }
 }

--- a/packages/rocket-file-uploads-azure-infrastructure/src/index.ts
+++ b/packages/rocket-file-uploads-azure-infrastructure/src/index.ts
@@ -1,12 +1,12 @@
 import { InfrastructureRocket } from '@boostercloud/framework-provider-azure-infrastructure'
 import { Synth } from './synth/synth'
 import { Functions } from './functions/functions'
-import { RocketFilesParams } from '@boostercloud/rocket-file-uploads-types'
+import { RocketFilesConfiguration } from '@boostercloud/rocket-file-uploads-types'
 
-const AzureRocketFiles = (params: RocketFilesParams): InfrastructureRocket => ({
-  mountStack: Synth.mountStack.bind(Synth, params),
-  mountFunctions: Functions.mountFunctions.bind(Synth, params),
-  getFunctionAppName: Functions.getFunctionAppName.bind(Synth, params),
+const AzureRocketFiles = (configuration: RocketFilesConfiguration): InfrastructureRocket => ({
+  mountStack: Synth.mountStack.bind(Synth, configuration),
+  mountFunctions: Functions.mountFunctions.bind(Synth, configuration),
+  getFunctionAppName: Functions.getFunctionAppName.bind(Synth, configuration),
 })
 
 export default AzureRocketFiles

--- a/packages/rocket-file-uploads-azure-infrastructure/src/synth/synth.ts
+++ b/packages/rocket-file-uploads-azure-infrastructure/src/synth/synth.ts
@@ -1,13 +1,13 @@
 import { BoosterConfig } from '@boostercloud/framework-types'
 import { ApplicationSynthStack, RocketUtils } from '@boostercloud/framework-provider-azure-infrastructure'
-import { RocketFilesParams } from '@boostercloud/rocket-file-uploads-types'
+import { RocketFilesConfiguration } from '@boostercloud/rocket-file-uploads-types'
 import { TerraformFunctionApp } from './terraform-function-app'
 import { TerraformStorageAccount } from './terraform-storage-account'
 import { TerraformStorageContainer } from './terraform-storage-container'
 
 export class Synth {
   public static mountStack(
-    params: RocketFilesParams,
+    configuration: RocketFilesConfiguration,
     config: BoosterConfig,
     applicationSynthStack: ApplicationSynthStack,
     utils: RocketUtils
@@ -27,7 +27,7 @@ export class Synth {
       terraformStack,
       appPrefix,
       rocketStorage,
-      params.containerName,
+      configuration.containerName,
       utils
     )
     rocketStack.push(blobContainer)

--- a/packages/rocket-file-uploads-azure-infrastructure/src/synth/synth.ts
+++ b/packages/rocket-file-uploads-azure-infrastructure/src/synth/synth.ts
@@ -17,7 +17,14 @@ export class Synth {
     const resourceGroup = applicationSynthStack.resourceGroup!
     const rocketStack = applicationSynthStack.rocketStack ?? []
 
-    const rocketStorage = TerraformStorageAccount.build(terraformStack, resourceGroup, appPrefix, utils, config)
+    const rocketStorage = TerraformStorageAccount.build(
+      terraformStack,
+      resourceGroup,
+      appPrefix,
+      utils,
+      config,
+      configuration.azureInfra?.storageAccountName
+    )
 
     applicationSynthStack.functionApp!.addOverride('app_settings', {
       ROCKET_STORAGE_KEY: `${rocketStorage.primaryAccessKey}`,

--- a/packages/rocket-file-uploads-azure-infrastructure/src/synth/terraform-storage-account.ts
+++ b/packages/rocket-file-uploads-azure-infrastructure/src/synth/terraform-storage-account.ts
@@ -1,8 +1,8 @@
 import { TerraformStack } from 'cdktf'
 import { ResourceGroup, StorageAccount } from '@cdktf/provider-azurerm'
 import { RocketUtils } from '@boostercloud/framework-provider-azure-infrastructure'
-import { storageName } from '@boostercloud/rocket-file-uploads-types'
 import { BoosterConfig } from '@boostercloud/framework-types'
+import { azureStorageName } from '@boostercloud/rocket-file-uploads-types'
 
 export class TerraformStorageAccount {
   static build(
@@ -10,11 +10,13 @@ export class TerraformStorageAccount {
     resourceGroup: ResourceGroup,
     appPrefix: string,
     utils: RocketUtils,
-    config: BoosterConfig
+    config: BoosterConfig,
+    storageAccountNameParameter?: string
   ): StorageAccount {
     const id = utils.toTerraformName(appPrefix, 'rfst')
+    const storageAccountName = azureStorageName(config.appName, config.environmentName, storageAccountNameParameter)
     return new StorageAccount(terraformStack, id, {
-      name: storageName(config.appName, config.environmentName),
+      name: storageAccountName,
       resourceGroupName: resourceGroup.name,
       location: resourceGroup.location,
       accountReplicationType: 'LRS',

--- a/packages/rocket-file-uploads-azure/src/file-uploaded.ts
+++ b/packages/rocket-file-uploads-azure/src/file-uploaded.ts
@@ -1,14 +1,14 @@
-import { RocketFilesParam, RocketFilesParams } from '@boostercloud/rocket-file-uploads-types'
+import { RocketFilesConfiguration } from '@boostercloud/rocket-file-uploads-types'
 import { Context, ContextBindingData } from '@azure/functions'
 
 export function getMetadataFromRequest(request: unknown): ContextBindingData {
   return (request as Context).bindingData
 }
 
-export function validateMetadata(params: RocketFilesParams, metadata: ContextBindingData): boolean {
+export function validateMetadata(configuration: RocketFilesConfiguration, metadata: ContextBindingData): boolean {
   const blobTrigger = metadata.blobTrigger as string
-  const directoryFound = params.params.find((p: RocketFilesParam) =>
-    blobTrigger.startsWith(`${params.containerName}/${p.directory}`)
+  const directoryFound = configuration.directories.find((directory: string) =>
+    blobTrigger.startsWith(`${configuration.containerName}/${directory}`)
   )
 
   if (!directoryFound) {

--- a/packages/rocket-file-uploads-azure/src/handlers/blob-service.ts
+++ b/packages/rocket-file-uploads-azure/src/handlers/blob-service.ts
@@ -1,5 +1,6 @@
 import * as storage from '@azure/storage-blob'
-import { ListItem } from '@boostercloud/rocket-file-uploads-types'
+import { azureStorageName, ListItem, RocketFilesConfiguration } from '@boostercloud/rocket-file-uploads-types'
+import { BoosterConfig } from '@boostercloud/framework-types'
 
 /**
  * Write SasUrl requires `Storage Blob Data Contributor` role.
@@ -9,8 +10,16 @@ export class BlobService {
   private readonly DEFAULT_PERMISSIONS = 'r'
   private readonly DEFAULT_EXPIRES_ON_SECONDS = 86400
   private readonly STORAGE_ACCOUNT_ENDPOINT = 'blob.core.windows.net'
+  private readonly storageAccount: string
 
-  constructor(readonly storageAccount: string) {}
+  constructor(readonly configuration: BoosterConfig, readonly rocketFilesConfiguration: RocketFilesConfiguration) {
+    const storageAccountNameParameter = rocketFilesConfiguration.azureInfra?.storageAccountName
+    this.storageAccount = azureStorageName(
+      configuration.appName,
+      configuration.environmentName,
+      storageAccountNameParameter
+    )
+  }
 
   public getBlobSasUrl(
     containerName: string,

--- a/packages/rocket-file-uploads-azure/src/handlers/list.ts
+++ b/packages/rocket-file-uploads-azure/src/handlers/list.ts
@@ -1,8 +1,14 @@
 import { BoosterConfig } from '@boostercloud/framework-types'
 import { BlobService } from './blob-service'
-import { storageName, ListItem } from '@boostercloud/rocket-file-uploads-types'
+import { ListItem, RocketFilesConfiguration } from '@boostercloud/rocket-file-uploads-types'
 
-export async function list(config: BoosterConfig, containerName: string, directory: string): Promise<Array<ListItem>> {
-  const storageAccount = storageName(config.appName, config.environmentName)
-  return new BlobService(storageAccount).listBlobFolder(containerName, directory)
+export async function list(
+  config: BoosterConfig,
+  rocketFilesConfiguration: RocketFilesConfiguration,
+  directory: string
+): Promise<Array<ListItem>> {
+  return new BlobService(config, rocketFilesConfiguration).listBlobFolder(
+    rocketFilesConfiguration.containerName,
+    directory
+  )
 }

--- a/packages/rocket-file-uploads-azure/src/handlers/presigned-get.ts
+++ b/packages/rocket-file-uploads-azure/src/handlers/presigned-get.ts
@@ -1,13 +1,16 @@
 import { BoosterConfig } from '@boostercloud/framework-types'
 import { BlobService } from './blob-service'
-import { storageName } from '@boostercloud/rocket-file-uploads-types'
+import { RocketFilesConfiguration } from '@boostercloud/rocket-file-uploads-types'
 
 export async function presignedGet(
   config: BoosterConfig,
-  containerName: string,
+  rocketFilesConfiguration: RocketFilesConfiguration,
   directory: string,
   fileName: string
 ): Promise<string> {
-  const storageAccount = storageName(config.appName, config.environmentName)
-  return new BlobService(storageAccount).getBlobSasUrl(containerName, directory, fileName)
+  return new BlobService(config, rocketFilesConfiguration).getBlobSasUrl(
+    rocketFilesConfiguration.containerName,
+    directory,
+    fileName
+  )
 }

--- a/packages/rocket-file-uploads-azure/src/handlers/presigned-put.ts
+++ b/packages/rocket-file-uploads-azure/src/handlers/presigned-put.ts
@@ -1,15 +1,19 @@
 import { BoosterConfig } from '@boostercloud/framework-types'
 import { BlobService } from './blob-service'
-import { storageName } from '@boostercloud/rocket-file-uploads-types'
+import { RocketFilesConfiguration } from '@boostercloud/rocket-file-uploads-types'
 
 const WRITE_PERMISSION = 'w'
 
 export async function presignedPut(
   config: BoosterConfig,
-  containerName: string,
+  rocketFilesConfiguration: RocketFilesConfiguration,
   directory: string,
   fileName: string
 ): Promise<string> {
-  const storageAccount = storageName(config.appName, config.environmentName)
-  return new BlobService(storageAccount).getBlobSasUrl(containerName, directory, fileName, WRITE_PERMISSION)
+  return new BlobService(config, rocketFilesConfiguration).getBlobSasUrl(
+    rocketFilesConfiguration.containerName,
+    directory,
+    fileName,
+    WRITE_PERMISSION
+  )
 }

--- a/packages/rocket-file-uploads-core/src/file-handler.ts
+++ b/packages/rocket-file-uploads-core/src/file-handler.ts
@@ -1,52 +1,47 @@
 import { BoosterConfig, RocketDescriptor } from '@boostercloud/framework-types'
-import {
-  ListItem,
-  RocketFilesParam,
-  RocketFilesParams,
-  RocketFilesProviderLibrary,
-} from '@boostercloud/rocket-file-uploads-types'
+import { ListItem, RocketFilesConfiguration, RocketFilesProviderLibrary } from '@boostercloud/rocket-file-uploads-types'
 
 export class FileHandler {
   private _provider: RocketFilesProviderLibrary
   private _rocket: RocketDescriptor
-  private _parameters: RocketFilesParams
+  private _configuration: RocketFilesConfiguration
 
   constructor(readonly config: BoosterConfig) {
     this._rocket = FileHandler.getRocketFromConfiguration(config)
-    this._parameters = this._rocket.parameters as RocketFilesParams
-    this._provider = require(this._parameters.rocketProviderPackage)
+    this._configuration = this._rocket.parameters as RocketFilesConfiguration
+    this._provider = require(this._configuration.rocketProviderPackage)
   }
 
   public presignedGet(directory: string, fileName: string): Promise<string> {
     this.checkDirectory(directory)
-    return this._provider.presignedGet(this.config, this._parameters.containerName, directory, fileName)
+    return this._provider.presignedGet(this.config, this._configuration.containerName, directory, fileName)
   }
 
   public presignedPut(directory: string, fileName: string): Promise<string> {
     this.checkDirectory(directory)
-    return this._provider.presignedPut(this.config, this._parameters.containerName, directory, fileName)
+    return this._provider.presignedPut(this.config, this._configuration.containerName, directory, fileName)
   }
 
   public list(directory: string): Promise<Array<ListItem>> {
     this.checkDirectory(directory)
-    return this._provider.list(this.config, this._parameters.containerName, directory)
+    return this._provider.list(this.config, this._configuration.containerName, directory)
   }
 
   private checkDirectory(directory: string): void {
-    if (!this._parameters.params.map((param: RocketFilesParam) => param.directory).includes(directory)) {
+    if (!this._configuration.directories.includes(directory)) {
       throw new Error(`Invalid directory ${directory}`)
     }
   }
 
   private static getRocketFromConfiguration(config: BoosterConfig): RocketDescriptor {
-    const rocket = config.rockets?.find(
+    const rocketDescriptor = config.rockets?.find(
       (rocket) =>
         rocket.packageName == '@boostercloud/rocket-file-uploads-azure-infrastructure' ||
         rocket.packageName == '@boostercloud/rocket-file-uploads-local-infrastructure'
     ) as RocketDescriptor
-    if (!rocket) {
+    if (!rocketDescriptor) {
       throw new Error('Rocket not found. Please make sure you have setup the rocket packageName correctly')
     }
-    return rocket
+    return rocketDescriptor
   }
 }

--- a/packages/rocket-file-uploads-core/src/file-handler.ts
+++ b/packages/rocket-file-uploads-core/src/file-handler.ts
@@ -4,31 +4,31 @@ import { ListItem, RocketFilesConfiguration, RocketFilesProviderLibrary } from '
 export class FileHandler {
   private _provider: RocketFilesProviderLibrary
   private _rocket: RocketDescriptor
-  private _configuration: RocketFilesConfiguration
+  private _rocketFilesConfiguration: RocketFilesConfiguration
 
   constructor(readonly config: BoosterConfig) {
     this._rocket = FileHandler.getRocketFromConfiguration(config)
-    this._configuration = this._rocket.parameters as RocketFilesConfiguration
-    this._provider = require(this._configuration.rocketProviderPackage)
+    this._rocketFilesConfiguration = this._rocket.parameters as RocketFilesConfiguration
+    this._provider = require(this._rocketFilesConfiguration.rocketProviderPackage)
   }
 
   public presignedGet(directory: string, fileName: string): Promise<string> {
     this.checkDirectory(directory)
-    return this._provider.presignedGet(this.config, this._configuration.containerName, directory, fileName)
+    return this._provider.presignedGet(this.config, this._rocketFilesConfiguration, directory, fileName)
   }
 
   public presignedPut(directory: string, fileName: string): Promise<string> {
     this.checkDirectory(directory)
-    return this._provider.presignedPut(this.config, this._configuration.containerName, directory, fileName)
+    return this._provider.presignedPut(this.config, this._rocketFilesConfiguration, directory, fileName)
   }
 
   public list(directory: string): Promise<Array<ListItem>> {
     this.checkDirectory(directory)
-    return this._provider.list(this.config, this._configuration.containerName, directory)
+    return this._provider.list(this.config, this._rocketFilesConfiguration, directory)
   }
 
   private checkDirectory(directory: string): void {
-    if (!this._configuration.directories.includes(directory)) {
+    if (!this._rocketFilesConfiguration.directories.includes(directory)) {
       throw new Error(`Invalid directory ${directory}`)
     }
   }

--- a/packages/rocket-file-uploads-core/src/file-uploaded.ts
+++ b/packages/rocket-file-uploads-core/src/file-uploaded.ts
@@ -1,7 +1,7 @@
 import { BoosterConfig, EventEnvelope, UUID } from '@boostercloud/framework-types'
 import {
   RocketFilesBlobUploaded,
-  RocketFilesParams,
+  RocketFilesConfiguration,
   UploadedFileEntity,
   UploadedFileEvent,
 } from '@boostercloud/rocket-file-uploads-types'
@@ -9,7 +9,7 @@ import {
 export async function fileUploaded(
   config: BoosterConfig,
   request: unknown,
-  params: RocketFilesParams
+  params: RocketFilesConfiguration
 ): Promise<unknown> {
   const provider = require(params.rocketProviderPackage)
   const metadata = provider.getMetadataFromRequest(request)

--- a/packages/rocket-file-uploads-core/src/index.ts
+++ b/packages/rocket-file-uploads-core/src/index.ts
@@ -1,6 +1,7 @@
 import { BoosterConfig, RocketDescriptor } from '@boostercloud/framework-types'
 import {
   functionID,
+  RocketFilesAzureInfraParameters,
   RocketFilesConfiguration,
   RocketFilesUserConfiguration,
   RocketProviderPackageType,
@@ -12,11 +13,12 @@ export { FileHandler } from './file-handler'
 export class BoosterRocketFiles {
   constructor(readonly config: BoosterConfig, readonly userConfiguration: RocketFilesUserConfiguration) {}
 
-  public rocketForAzure(): RocketDescriptor {
+  public rocketForAzure(azureInfraParameters?: RocketFilesAzureInfraParameters): RocketDescriptor {
     const configuration = BoosterRocketFiles.buildParameters(
       this.userConfiguration,
       '@boostercloud/rocket-file-uploads-azure'
     )
+    configuration.azureInfra = azureInfraParameters
     this.register(configuration)
     return {
       packageName: '@boostercloud/rocket-file-uploads-azure-infrastructure',

--- a/packages/rocket-file-uploads-core/src/index.ts
+++ b/packages/rocket-file-uploads-core/src/index.ts
@@ -1,27 +1,49 @@
 import { BoosterConfig, RocketDescriptor } from '@boostercloud/framework-types'
-import { functionID, RocketFilesParams } from '@boostercloud/rocket-file-uploads-types'
+import {
+  functionID,
+  RocketFilesConfiguration,
+  RocketFilesUserConfiguration,
+  RocketProviderPackageType,
+} from '@boostercloud/rocket-file-uploads-types'
 import { fileUploaded } from './file-uploaded'
 
 export { FileHandler } from './file-handler'
 
 export class BoosterRocketFiles {
-  public constructor(readonly config: BoosterConfig, readonly params: RocketFilesParams) {
+  public rocketForAzure(config: BoosterConfig, userConfiguration: RocketFilesUserConfiguration): RocketDescriptor {
+    const configuration = BoosterRocketFiles.buildParameters(
+      userConfiguration,
+      '@boostercloud/rocket-file-uploads-azure'
+    )
+    this.register(config, configuration)
+    return {
+      packageName: '@boostercloud/rocket-file-uploads-azure-infrastructure',
+      parameters: configuration,
+    }
+  }
+
+  public rocketForLocal(config: BoosterConfig, userConfiguration: RocketFilesUserConfiguration): RocketDescriptor {
+    const configuration = BoosterRocketFiles.buildParameters(
+      userConfiguration,
+      '@boostercloud/rocket-file-uploads-local'
+    )
+    this.register(config, configuration)
+    return {
+      packageName: '@boostercloud/rocket-file-uploads-local-infrastructure',
+      parameters: configuration,
+    }
+  }
+
+  private register(config: BoosterConfig, configuration: RocketFilesConfiguration): void {
     config.registerRocketFunction(functionID, async (config: BoosterConfig, request: unknown) => {
-      return fileUploaded(config, request, params)
+      return fileUploaded(config, request, configuration)
     })
   }
 
-  public rocketForAzure(): RocketDescriptor {
-    return {
-      packageName: '@boostercloud/rocket-file-uploads-azure-infrastructure',
-      parameters: this.params,
-    }
-  }
-
-  public rocketForLocal(): RocketDescriptor {
-    return {
-      packageName: '@boostercloud/rocket-file-uploads-local-infrastructure',
-      parameters: this.params,
-    }
+  private static buildParameters(
+    userConfiguration: RocketFilesUserConfiguration,
+    rocketProviderPackage: RocketProviderPackageType
+  ): RocketFilesConfiguration {
+    return { ...userConfiguration, rocketProviderPackage: rocketProviderPackage }
   }
 }

--- a/packages/rocket-file-uploads-core/src/index.ts
+++ b/packages/rocket-file-uploads-core/src/index.ts
@@ -10,32 +10,34 @@ import { fileUploaded } from './file-uploaded'
 export { FileHandler } from './file-handler'
 
 export class BoosterRocketFiles {
-  public rocketForAzure(config: BoosterConfig, userConfiguration: RocketFilesUserConfiguration): RocketDescriptor {
+  constructor(readonly config: BoosterConfig, readonly userConfiguration: RocketFilesUserConfiguration) {}
+
+  public rocketForAzure(): RocketDescriptor {
     const configuration = BoosterRocketFiles.buildParameters(
-      userConfiguration,
+      this.userConfiguration,
       '@boostercloud/rocket-file-uploads-azure'
     )
-    this.register(config, configuration)
+    this.register(configuration)
     return {
       packageName: '@boostercloud/rocket-file-uploads-azure-infrastructure',
       parameters: configuration,
     }
   }
 
-  public rocketForLocal(config: BoosterConfig, userConfiguration: RocketFilesUserConfiguration): RocketDescriptor {
+  public rocketForLocal(): RocketDescriptor {
     const configuration = BoosterRocketFiles.buildParameters(
-      userConfiguration,
+      this.userConfiguration,
       '@boostercloud/rocket-file-uploads-local'
     )
-    this.register(config, configuration)
+    this.register(configuration)
     return {
       packageName: '@boostercloud/rocket-file-uploads-local-infrastructure',
       parameters: configuration,
     }
   }
 
-  private register(config: BoosterConfig, configuration: RocketFilesConfiguration): void {
-    config.registerRocketFunction(functionID, async (config: BoosterConfig, request: unknown) => {
+  private register(configuration: RocketFilesConfiguration): void {
+    this.config.registerRocketFunction(functionID, async (config: BoosterConfig, request: unknown) => {
       return fileUploaded(config, request, configuration)
     })
   }

--- a/packages/rocket-file-uploads-local-infrastructure/src/index.ts
+++ b/packages/rocket-file-uploads-local-infrastructure/src/index.ts
@@ -1,9 +1,9 @@
 import { InfrastructureRocket } from '@boostercloud/framework-provider-local-infrastructure'
 import { Infra } from './infra'
-import { RocketFilesParams } from '@boostercloud/rocket-file-uploads-types'
+import { RocketFilesConfiguration } from '@boostercloud/rocket-file-uploads-types'
 
-const AzureRocketFiles = (params: RocketFilesParams): InfrastructureRocket => ({
-  mountStack: Infra.mountStack.bind(Infra, params),
+const AzureRocketFiles = (configuration: RocketFilesConfiguration): InfrastructureRocket => ({
+  mountStack: Infra.mountStack.bind(Infra, configuration),
 })
 
 export default AzureRocketFiles

--- a/packages/rocket-file-uploads-local-infrastructure/src/infra.ts
+++ b/packages/rocket-file-uploads-local-infrastructure/src/infra.ts
@@ -1,15 +1,15 @@
 import { BoosterConfig, rocketFunctionIDEnvVar } from '@boostercloud/framework-types'
 import { Router } from 'express'
-import { functionID, RocketFilesParam, RocketFilesParams } from '@boostercloud/rocket-file-uploads-types'
+import { functionID, RocketFilesConfiguration } from '@boostercloud/rocket-file-uploads-types'
 import { FileController } from './controllers/file-controller'
 import { fsWatch } from './fs-watch'
 
 export class Infra {
-  public static mountStack(params: RocketFilesParams, config: BoosterConfig, router: Router): void {
+  public static mountStack(params: RocketFilesConfiguration, config: BoosterConfig, router: Router): void {
     process.env[rocketFunctionIDEnvVar] = functionID
-    params.params.forEach((parameter: RocketFilesParam) => {
-      router.use(`/${params.containerName}`, new FileController(params.containerName, parameter.directory).router)
-      fsWatch(params.containerName, parameter.directory)
+    params.directories.forEach((directory: string) => {
+      router.use(`/${params.containerName}`, new FileController(params.containerName, directory).router)
+      fsWatch(params.containerName, directory)
     })
   }
 }

--- a/packages/rocket-file-uploads-local/src/file-uploaded.ts
+++ b/packages/rocket-file-uploads-local/src/file-uploaded.ts
@@ -1,4 +1,4 @@
-import { RocketFilesParams } from '@boostercloud/rocket-file-uploads-types'
+import { RocketFilesConfiguration } from '@boostercloud/rocket-file-uploads-types'
 
 interface LocalBindingData {
   name: string
@@ -9,6 +9,6 @@ export function getMetadataFromRequest(request: unknown): LocalBindingData {
   return request as LocalBindingData
 }
 
-export function validateMetadata(params: RocketFilesParams, metadata: LocalBindingData): boolean {
+export function validateMetadata(configuration: RocketFilesConfiguration, metadata: LocalBindingData): boolean {
   return true
 }

--- a/packages/rocket-file-uploads-local/src/handlers/list.ts
+++ b/packages/rocket-file-uploads-local/src/handlers/list.ts
@@ -1,12 +1,16 @@
 import { BoosterConfig } from '@boostercloud/framework-types'
-import { ListItem } from '@boostercloud/rocket-file-uploads-types'
+import { ListItem, RocketFilesConfiguration } from '@boostercloud/rocket-file-uploads-types'
 import * as fs from 'fs'
 import * as path from 'path'
 
-export async function list(config: BoosterConfig, containerName: string, directory: string): Promise<Array<ListItem>> {
+export async function list(
+  _config: BoosterConfig,
+  rocketFilesConfiguration: RocketFilesConfiguration,
+  directory: string
+): Promise<Array<ListItem>> {
   const result = [] as Array<ListItem>
   // TODO validate directory
-  const _path = path.join(process.cwd(), containerName, directory)
+  const _path = path.join(process.cwd(), rocketFilesConfiguration.containerName, directory)
   const files = fs.readdirSync(_path)
   files.forEach((file) => {
     const stats = fs.statSync(path.join(_path, file))

--- a/packages/rocket-file-uploads-local/src/handlers/presigned-get.ts
+++ b/packages/rocket-file-uploads-local/src/handlers/presigned-get.ts
@@ -1,10 +1,11 @@
 import { BoosterConfig } from '@boostercloud/framework-types'
+import { RocketFilesConfiguration } from '@boostercloud/rocket-file-uploads-types'
 
 export async function presignedGet(
-  config: BoosterConfig,
-  containerName: string,
+  _config: BoosterConfig,
+  rocketFilesConfiguration: RocketFilesConfiguration,
   directory: string,
   fileName: string
 ): Promise<string> {
-  return `${containerName}/${directory}/${fileName}`
+  return `${rocketFilesConfiguration.containerName}/${directory}/${fileName}`
 }

--- a/packages/rocket-file-uploads-local/src/handlers/presigned-put.ts
+++ b/packages/rocket-file-uploads-local/src/handlers/presigned-put.ts
@@ -1,10 +1,11 @@
 import { BoosterConfig } from '@boostercloud/framework-types'
+import { RocketFilesConfiguration } from '@boostercloud/rocket-file-uploads-types'
 
 export async function presignedPut(
-  config: BoosterConfig,
-  containerName: string,
+  _config: BoosterConfig,
+  rocketFilesConfiguration: RocketFilesConfiguration,
   directory: string,
   fileName: string
 ): Promise<string> {
-  return `${containerName}/${directory}/${fileName}`
+  return `${rocketFilesConfiguration.containerName}/${directory}/${fileName}`
 }

--- a/packages/rocket-file-uploads-types/src/constants.ts
+++ b/packages/rocket-file-uploads-types/src/constants.ts
@@ -1,2 +1,8 @@
-export const storageName = (applicationName: string, environmentName: string): string =>
-  `${applicationName}rf${environmentName}`.replace(/([-_])/gi, '').substr(0, 24)
+export function azureStorageName(
+  applicationName: string,
+  environmentName: string,
+  storageAccountNameParameter?: string
+): string {
+  const defaultAccountName = `${applicationName}rf${environmentName}`.replace(/([-_])/gi, '').substring(0, 24)
+  return storageAccountNameParameter || defaultAccountName
+}

--- a/packages/rocket-file-uploads-types/src/rocket-files-params.ts
+++ b/packages/rocket-file-uploads-types/src/rocket-files-params.ts
@@ -1,15 +1,14 @@
 export const functionID = 'rocket-files'
 
-export interface RocketFilesParam {
-  directory: string
+export interface RocketFilesUserConfiguration {
+  containerName: string
+  directories: Array<string>
 }
 
 export type RocketProviderPackageType =
   | '@boostercloud/rocket-file-uploads-azure'
   | '@boostercloud/rocket-file-uploads-local'
 
-export interface RocketFilesParams {
+export interface RocketFilesConfiguration extends RocketFilesUserConfiguration {
   rocketProviderPackage: RocketProviderPackageType
-  containerName: string
-  params: Array<RocketFilesParam>
 }

--- a/packages/rocket-file-uploads-types/src/rocket-files-params.ts
+++ b/packages/rocket-file-uploads-types/src/rocket-files-params.ts
@@ -9,6 +9,11 @@ export type RocketProviderPackageType =
   | '@boostercloud/rocket-file-uploads-azure'
   | '@boostercloud/rocket-file-uploads-local'
 
+export interface RocketFilesAzureInfraParameters {
+  storageAccountName: string
+}
+
 export interface RocketFilesConfiguration extends RocketFilesUserConfiguration {
   rocketProviderPackage: RocketProviderPackageType
+  azureInfra?: RocketFilesAzureInfraParameters
 }

--- a/packages/rocket-file-uploads-types/src/rocket-files-provider-library.ts
+++ b/packages/rocket-file-uploads-types/src/rocket-files-provider-library.ts
@@ -1,8 +1,23 @@
 import { BoosterConfig } from '@boostercloud/framework-types'
 import { ListItem } from './list-item'
+import { RocketFilesConfiguration } from './rocket-files-params'
 
 export interface RocketFilesProviderLibrary {
-  presignedGet(config: BoosterConfig, containerName: string, directory: string, fileName: string): Promise<string>
-  presignedPut(config: BoosterConfig, containerName: string, directory: string, fileName: string): Promise<string>
-  list(config: BoosterConfig, containerName: string, directory: string): Promise<Array<ListItem>>
+  presignedGet(
+    config: BoosterConfig,
+    rocketFilesConfiguration: RocketFilesConfiguration,
+    directory: string,
+    fileName: string
+  ): Promise<string>
+  presignedPut(
+    config: BoosterConfig,
+    rocketFilesConfiguration: RocketFilesConfiguration,
+    directory: string,
+    fileName: string
+  ): Promise<string>
+  list(
+    config: BoosterConfig,
+    rocketFilesConfiguration: RocketFilesConfiguration,
+    directory: string
+  ): Promise<Array<ListItem>>
 }


### PR DESCRIPTION
Changes:

* Add a new parameter for Azure Provider to set the storage account name
* Remove the need of configure the RocketProviderPackage on the clients. It is now configured on the client.
* Simplify the parameters needed (see README.md)
* Updated documentation

**NOTE: This change is not backward compatible**