### PR TITLE
Add functionID as a request field when calling to BoosterRocketDispatcher on Local Provider

### DIFF
--- a/packages/rocket-file-uploads-local-infrastructure/src/fs-watch.ts
+++ b/packages/rocket-file-uploads-local-infrastructure/src/fs-watch.ts
@@ -1,6 +1,8 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import { boosterRocketDispatcher } from '@boostercloud/framework-core'
+import { functionID } from '@boostercloud/rocket-file-uploads-types'
+import { rocketFunctionIDEnvVar } from '@boostercloud/framework-types'
 
 export function fsWatch(storageName: string, containerName: string, directory: string, port: number): void {
   const _path = path.join(process.cwd(), storageName, containerName, directory)
@@ -11,6 +13,7 @@ export function fsWatch(storageName: string, containerName: string, directory: s
     const uri = `http://localhost:${port}/${path.join(storageName, containerName, directory, filename)}`
     const name = path.join(directory, filename)
     await boosterRocketDispatcher({
+      [rocketFunctionIDEnvVar]: functionID,
       uri: uri,
       name: name,
     })

--- a/packages/rocket-file-uploads-local-infrastructure/src/infra.ts
+++ b/packages/rocket-file-uploads-local-infrastructure/src/infra.ts
@@ -1,6 +1,6 @@
-import { BoosterConfig, rocketFunctionIDEnvVar } from '@boostercloud/framework-types'
+import { BoosterConfig } from '@boostercloud/framework-types'
 import { Router } from 'express'
-import { functionID, RocketFilesConfiguration, LOCAL_PORT_ENV } from '@boostercloud/rocket-file-uploads-types'
+import { RocketFilesConfiguration, LOCAL_PORT_ENV } from '@boostercloud/rocket-file-uploads-types'
 import { FileController } from './controllers/file-controller'
 import { fsWatch } from './fs-watch'
 import { InfrastructureRocketMetadata } from '@boostercloud/framework-provider-local-infrastructure'
@@ -12,7 +12,6 @@ export class Infra {
     router: Router,
     infrastructureRocketMetadata?: InfrastructureRocketMetadata
   ): void {
-    process.env[rocketFunctionIDEnvVar] = functionID
     const port = infrastructureRocketMetadata?.port ?? 3000
     process.env[LOCAL_PORT_ENV] = port.toString()
     rocketFilesConfiguration.userConfiguration.forEach((userConfiguration) => {


### PR DESCRIPTION
Add functionID as a request field when calling to BoosterRocketDispatcher on Local Provider

## Note:
* This PR depends on Booster PR: https://github.com/boostercloud/booster/pull/1186
* `package.json` needs to be updated with Booster version where previous PR is deployed