### PR TITLE
Fix wrong name sent in file watcher on local provider

### DIFF
--- a/packages/rocket-file-uploads-local-infrastructure/src/fs-watch.ts
+++ b/packages/rocket-file-uploads-local-infrastructure/src/fs-watch.ts
@@ -16,12 +16,11 @@ export function fsWatch(storageName: string, containerName: string, port: number
     const parsed = path.parse(filenameStr)
     if (new RegExp(/(^|[/\\])\../).test(filenameStr)) return // ignore files starting with a dot
     if (!isValidDirectory(parsed.dir, directories)) return
-    const name = path.join(storageName, containerName, filenameStr)
-    const uri = `http://localhost:${port}/${name}`
+    const uri = `http://localhost:${port}/${path.join(storageName, containerName, filenameStr)}`
     await boosterRocketDispatcher({
       [rocketFunctionIDEnvVar]: functionID,
       uri: uri,
-      name: name,
+      name: filenameStr,
     })
   })
 }


### PR DESCRIPTION
This PR fixes a bug found in the local provider's `fs-watch.ts`. The call to `boosterRocketDispatcher` set the `name` property with the full path, including the storage and container names, which is wrong; it should only be the file and its directories containing the file. e.g., `foo/bar/file.txt` instead of `storageName/containerName/foo/bar/file.txt`.